### PR TITLE
github actions: add cargo audit job

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,24 @@
+name: Audit
+
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    - cron '12 13 2 * *'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Cargo audit
+        run: cargo audit
+

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,5 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Cargo audit
-        run: cargo audit
+      - name: Audit server
+        run: cargo audit --deny warnings
+
+      - name: Audit test client
+        run: cargo audit --deny warnings
+        working-directory: misc/test-client

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Audit server
-        run: cargo audit --deny warnings
+        run: cargo audit --deny warnings --ignore RUSTSEC-2022-0071 # includes exception for unmaintained rusoto crate, should be resolved by #134
 
       - name: Audit test client
         run: cargo audit --deny warnings

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,11 +6,11 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   pull_request:
-    paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+    branches:
+      - main
+      - master
   schedule:
-    - cron '12 13 2 * *'
+    - cron: '12 13 2 * *'
 
 jobs:
   audit:
@@ -21,4 +21,3 @@ jobs:
 
       - name: Cargo audit
         run: cargo audit
-


### PR DESCRIPTION
Run `cargo audit` from the default runner image to give feedback on reported issues with dependencies.

Currently this fails, but running `cargo update` is suffient to address everything but the unmaintained warning about rusoto crates. Addressing that one requires porting to the aws sdk.