### PR TITLE
Ci fixes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           profile: minimal
           components: clippy, rustfmt
-          toolchain: 1.76
+          toolchain: 1.78
           override: true
 
       - name: Cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]


### PR DESCRIPTION
#115 rebase failed ci due to some bitrot. Try to address that here.

- Bump `zeroize` to 1.8.1 (cargo audit warning)
- Bump rustc to 1.78.0 for tests (diesel_cli dev-dependency)