### PR TITLE
Abort on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,4 +46,8 @@ aws-sdk-rds = "1.96"
 
 [profile.dev]
 opt-level = 3
+panic = "abort"
+
+[profile.release]
+panic = "abort"
 


### PR DESCRIPTION
This will ensure that panics that occur in spawned tasks immediately kill the process.